### PR TITLE
Recompute bounds on dragstart (do not cache)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -509,33 +509,31 @@ function getCancelElement(cancel: string | undefined, node: HTMLElement) {
   return cancelEl;
 }
 
-const computeBoundRect = memoize(
-  (bounds: string | Partial<DragBoundsCoords>, rootNode: HTMLElement) => {
-    if (typeof bounds === 'object') {
-      // we have the left right etc
-      const [windowWidth, windowHeight] = [window.innerWidth, window.innerHeight];
+function computeBoundRect(bounds: string | Partial<DragBoundsCoords>, rootNode: HTMLElement) {
+  if (typeof bounds === 'object') {
+    // we have the left right etc
+    const [windowWidth, windowHeight] = [window.innerWidth, window.innerHeight];
 
-      const { top = 0, left = 0, right = 0, bottom = 0 } = bounds;
+    const { top = 0, left = 0, right = 0, bottom = 0 } = bounds;
 
-      const computedRight = windowWidth - right;
-      const computedBottom = windowHeight - bottom;
+    const computedRight = windowWidth - right;
+    const computedBottom = windowHeight - bottom;
 
-      return { top, right: computedRight, bottom: computedBottom, left };
-    }
-
-    // It's a string
-    if (bounds === 'parent') return (rootNode.parentNode as HTMLElement).getBoundingClientRect();
-
-    const node = document.querySelector<HTMLElement>(bounds);
-
-    if (node === null)
-      throw new Error("The selector provided for bound doesn't exists in the document.");
-
-    const computedBounds = node!.getBoundingClientRect();
-
-    return computedBounds;
+    return { top, right: computedRight, bottom: computedBottom, left };
   }
-);
+
+  // It's a string
+  if (bounds === 'parent') return (rootNode.parentNode as HTMLElement).getBoundingClientRect();
+
+  const node = document.querySelector<HTMLElement>(bounds);
+
+  if (node === null)
+    throw new Error("The selector provided for bound doesn't exists in the document.");
+
+  const computedBounds = node!.getBoundingClientRect();
+
+  return computedBounds;
+}
 
 function setTranslate(xPos: number, yPos: number, el: HTMLElement, gpuAcceleration: boolean) {
   el.style.transform = gpuAcceleration


### PR DESCRIPTION
The reason I made this change is window resizing.  If you make a draggable and then change the window size, the draggable will have the old bounds still cached by `memoize`, so the bounds are wrong.  It wouldn't recompute even if you updated `options`.  This allowed you drag things off screen if you made the window smaller, for example.

From my understanding, `computeBoundRect` is only run on drag start, not every move event.  So I felt this wouldn't be bad for performance :)