### PR TITLE
Fixed the issue with wrong initial coordinates calculation for scaled elements

### DIFF
--- a/demo/src/routes/index.svelte
+++ b/demo/src/routes/index.svelte
@@ -31,6 +31,11 @@
 
   let progressY = tweened(0, { easing: sineIn });
   let progressX = tweened(0, { easing: sineIn });
+
+  const minScale = 0.25;
+  const maxScale = 4;
+  const scaleStep = 0.05;
+  let scale = 1;
 </script>
 
 <main>
@@ -132,9 +137,17 @@
         <input type="checkbox" bind:checked={options.disabled} />
       </label>
     </div>
+
+    <div>
+      <label>
+        Scale
+        <input type="range" min={minScale} max={maxScale} step={scaleStep} bind:value={scale} />
+        {scale}
+      </label>
+    </div>
   </div>
 
-  <div class="canvas">
+  <div class="canvas" style="transform: scale({scale});">
     <div use:draggable={options} class="box">
       hello
 
@@ -146,12 +159,12 @@
     </div>
   </div>
 
-  <div class="canvas">
+  <div class="canvas" style="transform: scale({scale});">
     <div
       use:draggable={{ ...options }}
       on:svelte-drag={(e) => {
-        progressX = e.detail.offsetX;
-        progressY = e.detail.offsetY;
+        progressX.set(e.detail.offsetX);
+        progressY.set(e.detail.offsetY);
       }}
       class="box"
     >
@@ -165,7 +178,7 @@
     </div>
   </div>
 
-  <div class="canvas">
+  <div class="canvas" style="transform: scale({scale});">
     <input type="number" bind:value={$progressX} />
     <input type="number" bind:value={$progressY} />
     <div
@@ -214,6 +227,7 @@
 
   .canvas {
     flex-grow: 1;
+    transform-origin: top left;
     background-color: #242629;
     border-left: 1px solid white;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		let inverseScale = node.offsetWidth / nodeRect.width;
 		if (isNaN(inverseScale)) inverseScale = 1;
 		return inverseScale;
-	}
+	};
 
 	function dragStart(e: TouchEvent | MouseEvent) {
 		if (disabled) return;
@@ -399,8 +399,8 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		const { clientX, clientY } = isTouchEvent(e) ? e.touches[0] : e;
 		const inverseScale = calculateInverseScale();
 
-		if (canMoveInX) initialX = clientX - (xOffset / inverseScale);
-		if (canMoveInY) initialY = clientY - (yOffset / inverseScale);
+		if (canMoveInX) initialX = clientX - xOffset / inverseScale;
+		if (canMoveInY) initialY = clientY - yOffset / inverseScale;
 
 		// Only the bounds uses these properties at the moment,
 		// may open up in the future if others need it

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,6 +350,13 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 	// On mobile, touch can become extremely janky without it
 	node.style.touchAction = 'none';
 
+	const calculateInverseScale = () => {
+		// Calculate the current scale of the node
+		let inverseScale = node.offsetWidth / nodeRect.width;
+		if (isNaN(inverseScale)) inverseScale = 1;
+		return inverseScale;
+	}
+
 	function dragStart(e: TouchEvent | MouseEvent) {
 		if (disabled) return;
 
@@ -390,9 +397,10 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		fireSvelteDragStartEvent(node);
 
 		const { clientX, clientY } = isTouchEvent(e) ? e.touches[0] : e;
+		const inverseScale = calculateInverseScale();
 
-		if (canMoveInX) initialX = clientX - xOffset;
-		if (canMoveInY) initialY = clientY - yOffset;
+		if (canMoveInX) initialX = clientX - (xOffset / inverseScale);
+		if (canMoveInY) initialY = clientY - (yOffset / inverseScale);
 
 		// Only the bounds uses these properties at the moment,
 		// may open up in the future if others need it
@@ -435,9 +443,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		// Get final values for clamping
 		let [finalX, finalY] = [clientX, clientY];
 
-		// Calculate the current scale of the node
-		let inverseScale = node.offsetWidth / nodeRect.width;
-		if (isNaN(inverseScale)) inverseScale = 1;
+		const inverseScale = calculateInverseScale();
 
 		if (computedBounds) {
 			// Client position is limited to this virtual boundary to prevent node going out of bounds


### PR DESCRIPTION
In my previous changes initial drag was working smoothly for scaled elements positioned at 0,0 but as the position changed it was starting to get wrong initial coordinates, causing the element to jump during dragging.

I've noticed that initial coordinate calculation was ignoring the element scale, causing this issue. I previously didn't play with this case in the demo and noticed it in my project once I've pulled the 2.3.0 so sorry for missing it in my previous PR :(