### PR TITLE
ignoreMultitouch Option for ignoring touch events with multiple touches (ex: pinch)

### DIFF
--- a/demo/src/routes/index.svelte
+++ b/demo/src/routes/index.svelte
@@ -11,6 +11,7 @@
 
   let options: DragOptions;
   $: options = {
+    ignoreMultitouch: false,
     applyUserSelectHack: true,
     axis: 'both',
     cancel: '.cancel',
@@ -135,6 +136,13 @@
       <label>
         Disabled
         <input type="checkbox" bind:checked={options.disabled} />
+      </label>
+    </div>
+
+    <div>
+      <label>
+        Ignore Multitouch
+        <input type="checkbox" bind:checked={options.ignoreMultitouch} />
       </label>
     </div>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		let inverseScale = node.offsetWidth / nodeRect.width;
 		if (isNaN(inverseScale)) inverseScale = 1;
 		return inverseScale;
-	}
+	};
 
 	function dragStart(e: TouchEvent | MouseEvent) {
 		if (disabled) return;
@@ -399,8 +399,8 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		const { clientX, clientY } = isTouchEvent(e) ? e.touches[0] : e;
 		const inverseScale = calculateInverseScale();
 
-		if (canMoveInX) initialX = clientX - (xOffset / inverseScale);
-		if (canMoveInY) initialY = clientY - (yOffset / inverseScale);
+		if (canMoveInX) initialX = clientX - xOffset / inverseScale;
+		if (canMoveInY) initialY = clientY - yOffset / inverseScale;
 
 		// Only the bounds uses these properties at the moment,
 		// may open up in the future if others need it

--- a/src/index.ts
+++ b/src/index.ts
@@ -116,6 +116,23 @@ export type DragOptions = {
 	applyUserSelectHack?: boolean;
 
 	/**
+	 * Ignores touch events with more than 1 touch.
+	 * This helps when you have multiple elements on a canvas where you want to implement
+	 * pinch-to-zoom behaviour.
+	 *
+	 * @default false
+	 *
+	 * @example
+	 * ```svelte
+	 * <!-- Ignore Multitouch -->
+	 * <div use:draggable={{ ignoreMultitouch: true }}>
+	 *   Text
+	 * </div>
+	 * ```
+	 */
+	ignoreMultitouch?: boolean;
+
+	/**
 	 * Disables dragging altogether.
 	 *
 	 * @default false
@@ -272,6 +289,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		gpuAcceleration = true,
 		applyUserSelectHack = true,
 		disabled = false,
+		ignoreMultitouch = false,
 
 		grid,
 
@@ -359,6 +377,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 
 	function dragStart(e: TouchEvent | MouseEvent) {
 		if (disabled) return;
+		if (ignoreMultitouch && e.type === 'touchstart' && (e as TouchEvent).touches.length > 1) return;
 
 		node.classList.add(defaultClass);
 
@@ -505,6 +524,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 			// Update all the values that need to be changed
 			axis = options.axis || 'both';
 			disabled = options.disabled ?? false;
+			ignoreMultitouch = options.ignoreMultitouch ?? false;
 			handle = options.handle;
 			bounds = options.bounds;
 			cancel = options.cancel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		let inverseScale = node.offsetWidth / nodeRect.width;
 		if (isNaN(inverseScale)) inverseScale = 1;
 		return inverseScale;
-	};
+	}
 
 	function dragStart(e: TouchEvent | MouseEvent) {
 		if (disabled) return;
@@ -399,8 +399,8 @@ export const draggable = (node: HTMLElement, options: DragOptions = {}) => {
 		const { clientX, clientY } = isTouchEvent(e) ? e.touches[0] : e;
 		const inverseScale = calculateInverseScale();
 
-		if (canMoveInX) initialX = clientX - xOffset / inverseScale;
-		if (canMoveInY) initialY = clientY - yOffset / inverseScale;
+		if (canMoveInX) initialX = clientX - (xOffset / inverseScale);
+		if (canMoveInY) initialY = clientY - (yOffset / inverseScale);
 
 		// Only the bounds uses these properties at the moment,
 		// may open up in the future if others need it


### PR DESCRIPTION
Added `ignoreMultitouch` option to ignore touch events with more than 1 touches. This helps when you are trying to implement a pinch to zoom behaviour to the container of draggable elements. Without this PR while pinching you'll also drag the elements. But after the PR you can disable that behaviour with the new option. Tried to show how it behaves in the video below (sadly it didn't capture the cursor but still gives an idea), also added the option to the demo (although you'll need to use `undefined` handles to test it easily on an iOS device or simulator). 

https://user-images.githubusercontent.com/53268/146022846-bfe9903e-4ea2-4c04-b36a-e3b5e9459d8f.mov


